### PR TITLE
Set redirect on fancybox image if not on the whole content

### DIFF
--- a/src/collective/fancybox/browser/templates/lightbox.pt
+++ b/src/collective/fancybox/browser/templates/lightbox.pt
@@ -43,6 +43,9 @@
                 fbCaption.classList.add('fancybox-caption__moved');
                         fbCaption.style.marginBottom = "-" + fbCaption.offsetHeight + "px";
                 $('.fancybox-content').off('click');
+                $('.fancybox-image').click(function(e) {
+                    window.location.href = document.querySelector('.captionbutton').href;
+                });
             },
         });
     })


### PR DESCRIPTION
This PR makes the fancybox image clickable so that it will follow the fancybox redirect without interfering with the fancybox close button.
